### PR TITLE
ENABLE HE0ASHE1

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -32,7 +32,9 @@
 #define BOARD_NO_NATIVE_USB
 
 // Avoid conflict with TIMER_SERVO when using the STM32 HAL
-#define TEMP_TIMER  5
+#if MOTHERBOARD == BOARD_MKS_ROBIN_NANO
+ #define TEMP_TIMER  5
+#endif
 
 //
 // EEPROM
@@ -94,9 +96,14 @@
 
 //
 // Heaters / Fans
-//
+////////////////////////////////////////////////////////////////////////////////
 #ifndef HEATER_0_PIN
-  #define HEATER_0_PIN                      PC3
+  #if ENABLED (HE1ASHE0)
+    #define HEATER_0_PIN                      PB0
+  #else
+    #define HEATER_0_PIN                      PC3
+  #endif
+  
 #endif
 #ifndef FAN_PIN
   #define FAN_PIN                           PB1   // FAN
@@ -107,7 +114,11 @@
 
 #if HOTENDS == 1 && DISABLED(HEATERS_PARALLEL)
   #ifndef FAN1_PIN
-    #define FAN1_PIN                        PB0
+    #if ENABLED (HE1ASHE0)
+          //#define FAN1_PIN                        PB0
+    #else
+          #define FAN1_PIN                        PB0
+    #endif
   #endif
 #elif !defined(HEATER_1_PIN)
   #define HEATER_1_PIN                      PB0


### PR DESCRIPTION
per chi vrucia MOSFET su hotend puo' usare HE1 al posto di HE0

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
